### PR TITLE
Add alert rule propagation itest

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -9,3 +9,12 @@ bases:
     run-on:
     - name: ubuntu
       channel: "22.04"
+parts:
+  cos-tool:
+    plugin: dump
+    source: .
+    build-packages:
+      - curl
+    override-pull: |
+      curl -L -O https://github.com/canonical/cos-tool/releases/latest/download/cos-tool-${CRAFT_TARGET_ARCH}
+      chmod +x cos-tool-*

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,11 +5,13 @@ type: charm
 bases:
   - build-on:
     - name: ubuntu
-      channel: "22.04"
+      channel: "20.04"
     run-on:
     - name: ubuntu
-      channel: "22.04"
+      channel: "20.04"
 parts:
+  charm:
+    build-packages: [ git ]
   cos-tool:
     plugin: dump
     source: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,4 +68,4 @@ warn_unused_ignores = false
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
-#asyncio_mode = "auto"
+asyncio_mode = "auto"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 ops
 lightkube >= 0.11
 lightkube-models >= 1.22.0.4
-parse

--- a/src/charm.py
+++ b/src/charm.py
@@ -215,7 +215,6 @@ class MimirK8SOperatorCharm(CharmBase):
         # Without multitenancy, the default is `anonymous`, and the ruler checks under
         # {RULES_DIR}/<tenant_id>
         tenant_dir = f"{RULER_STORAGE_DIR}/anonymous"
-        self._container.make_dir(tenant_dir, make_parents=True)
         for topology_identifier, rules_file in alerts.items():
             filename = f"juju_{topology_identifier}.rules"
             path = os.path.join(tenant_dir, filename)

--- a/src/charm.py
+++ b/src/charm.py
@@ -83,7 +83,7 @@ class MimirK8SOperatorCharm(CharmBase):
             endpoint_path="/api/v1/push",
         )
         # TODO add custom event to remote-write
-        self.framework.observe(self.on.receive_remote_write_relation_changed, self._configure)
+        self.framework.observe(self.remote_write_provider.on.alert_rules_changed, self._configure)
 
         self.grafana_source_provider = GrafanaSourceProvider(
             charm=self,

--- a/src/charm.py
+++ b/src/charm.py
@@ -113,7 +113,7 @@ class MimirK8SOperatorCharm(CharmBase):
 
         try:
             # TODO when we stop using `local`, mimir would require an API call or mimirtool to
-            # reload any newly pushed rules.
+            #  reload any newly pushed rules.
             self._set_alerts()
             restart = any(
                 [

--- a/src/charm.py
+++ b/src/charm.py
@@ -35,8 +35,6 @@ MIMIR_DIR = "/mimir"
 # the configured ruler storage local directory "/mimir/rules"; please set different paths, also
 # ensuring one is not a subdirectory of the other one
 RULES_DIR = f"{MIMIR_DIR}/rules"
-RULER_DATA_DIR = f"{MIMIR_DIR}/ruler_data"
-
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +112,8 @@ class MimirK8SOperatorCharm(CharmBase):
             return
 
         try:
+            # TODO when we stop using `local`, mimir would require an API call or mimirtool to
+            # reload any newly pushed rules.
             self._set_alerts()
             restart = any(
                 [
@@ -268,9 +268,6 @@ class MimirK8SOperatorCharm(CharmBase):
                     "replication_factor": 1,
                 }
             },
-            # "ruler": {
-            #     "rule_path": RULER_DATA_DIR,
-            # },
             "ruler_storage": {
                 "backend": "local",
                 "local": {

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,6 +9,7 @@
 import hashlib
 import logging
 import os
+import re
 import socket
 from typing import Optional
 
@@ -27,7 +28,6 @@ from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import Error as PebbleError
 from ops.pebble import Layer, PathError, ProtocolError
-from parse import search  # type: ignore
 
 MIMIR_CONFIG = "/etc/mimir/mimir-config.yaml"
 MIMIR_DIR = "/mimir"
@@ -313,12 +313,9 @@ class MimirK8SOperatorCharm(CharmBase):
         version_output, _ = self._container.exec(["/bin/mimir", "-version"]).wait_output()
         # Output looks like this:
         # Mimir, version 2.4.0 (branch: HEAD, revision: 32137ee)
-        result = search("Mimir, version {} ", version_output)
-
-        if result is None:
-            return result
-
-        return result[0]
+        if result := re.search("[Vv]ersion:?\s*(\S+)", version_output)
+            return result.group(1)
+        return None
 
     @property
     def hostname(self) -> str:

--- a/src/charm.py
+++ b/src/charm.py
@@ -94,6 +94,8 @@ class MimirK8SOperatorCharm(CharmBase):
             endpoint_port=self._http_listen_port,
             endpoint_path="/api/v1/push",
         )
+        # TODO add custom event to remote-write
+        self.framework.observe(self.on.receive_remote_write_relation_changed, self._configure)
 
         self.grafana_source_provider = GrafanaSourceProvider(
             charm=self,
@@ -215,6 +217,9 @@ class MimirK8SOperatorCharm(CharmBase):
         # Without multitenancy, the default is `anonymous`, and the ruler checks under
         # {RULES_DIR}/<tenant_id>
         tenant_dir = f"{RULER_STORAGE_DIR}/anonymous"
+        # Need to `make_dir` even though we have `make_dirs=True` below
+        # https://github.com/canonical/operator/issues/898
+        self._container.make_dir(tenant_dir, make_parents=True)
         for topology_identifier, rules_file in alerts.items():
             filename = f"juju_{topology_identifier}.rules"
             path = os.path.join(tenant_dir, filename)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -54,3 +54,10 @@ async def mimir_charm(ops_test: OpsTest):
     """Mimir charm used for integration testing."""
     charm = await ops_test.build_charm(".")
     return charm
+
+
+@pytest.fixture(scope="module", autouse=True)
+async def model_config(ops_test: OpsTest):
+    await ops_test.model.set_config(
+        {"logging-config": "<root>=WARNING; unit=DEBUG", "update-status-hook-interval": "60m"}
+    )

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -3,15 +3,32 @@
 
 import logging
 from pathlib import Path
+from typing import Optional
 
 import yaml
+from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
 
-async def get_unit_address(ops_test, app_name: str, unit_num: int) -> str:
-    status = await ops_test.model.get_status()  # noqa: F821
-    return status["applications"][app_name]["units"][f"{app_name}/{unit_num}"]["address"]
+async def get_address(ops_test: OpsTest, app_name: str, unit_num: Optional[int] = None) -> str:
+    """Find unit address for any application.
+
+    Args:
+        ops_test: pytest-operator plugin
+        app_name: string name of application
+        unit_num: integer number of a juju unit
+
+    Returns:
+        unit address as a string
+    """
+    status = await ops_test.model.get_status()
+    app = status["applications"][app_name]
+    return (
+        app.public_address
+        if unit_num is None
+        else app["units"][f"{app_name}/{unit_num}"]["address"]
+    )
 
 
 def oci_image(metadata_file: str, image_name: str) -> str:

--- a/tests/integration/test_alert_propagation.py
+++ b/tests/integration/test_alert_propagation.py
@@ -47,6 +47,8 @@ async def test_deploy_and_relate_charms(ops_test: OpsTest, mimir_charm):
 
 @pytest.mark.abort_on_fail
 async def test_rules_are_loaded(ops_test):
+    await asyncio.sleep(15)  # Give mimir a chance to reload the newly pushed rules
+
     address = await get_address(ops_test, mimir.name, 0)
     client = Mimir(host=address)
 

--- a/tests/integration/test_alert_propagation.py
+++ b/tests/integration/test_alert_propagation.py
@@ -3,16 +3,16 @@
 # See LICENSE file for licensing details.
 
 import asyncio
+import json
 import logging
 from types import SimpleNamespace
 
 import pytest
+import pytimeparse
+import yaml
 from helpers import get_address, oci_image
 from pytest_operator.plugin import OpsTest
 from workload import Mimir
-import json
-import yaml
-import pytimeparse
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +67,7 @@ async def test_rules_are_loaded(ops_test):
 
 
 @pytest.mark.abort_on_fail
-async def test_rules_are_loaded(ops_test):
+async def test_alerts_are_fired(ops_test):
     address = await get_address(ops_test, mimir.name, 0)
     client = Mimir(host=address)
 

--- a/tests/integration/test_alert_propagation.py
+++ b/tests/integration/test_alert_propagation.py
@@ -50,5 +50,7 @@ async def test_rules_and_alerts_are_available(ops_test):
     client = Mimir(host=address)
     alerts = await client.api_request("/prometheus/api/v1/alerts")
     rules = await client.api_request("/prometheus/api/v1/rules")
+    groups = await client.api_request("/ruler/rule_groups")
     logger.info("alerts: %s", alerts)
     logger.info("rules: %s", rules)
+    logger.info("groups: %s", groups)

--- a/tests/integration/test_alert_propagation.py
+++ b/tests/integration/test_alert_propagation.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+from types import SimpleNamespace
+
+import pytest
+from helpers import get_address, oci_image
+from pytest_operator.plugin import OpsTest
+from workload import Mimir
+
+logger = logging.getLogger(__name__)
+
+mimir = SimpleNamespace(
+    name="mimir", resources={"mimir-image": oci_image("./metadata.yaml", "mimir-image")}
+)
+tester = SimpleNamespace(charm="avalanche-k8s", name="avalanche")
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_and_relate_charms(ops_test: OpsTest, mimir_charm):
+    """Test that Mimir can be related with Prometheus over prometheus_scrape."""
+    # Build charm from local source folder
+    # mimir_charm = await ops_test.build_charm(".")
+    await asyncio.gather(
+        ops_test.model.deploy(
+            mimir_charm,
+            resources=mimir.resources,
+            application_name=mimir.name,
+            trust=True,
+        ),
+        ops_test.model.deploy(
+            tester.charm,
+            application_name=tester.name,
+            channel="edge",
+        ),
+    )
+
+    await ops_test.model.add_relation(f"{mimir.name}:receive-remote-write", tester.name)
+    await ops_test.model.wait_for_idle(status="active")
+
+
+# TODO wait until target is there
+
+
+async def test_rules_and_alerts_are_available(ops_test):
+    address = await get_address(ops_test, mimir.name, 0)
+    client = Mimir(host=address)
+    alerts = await client.api_request("/prometheus/api/v1/alerts")
+    rules = await client.api_request("/prometheus/api/v1/rules")
+    logger.info("alerts: %s", alerts)
+    logger.info("rules: %s", rules)

--- a/tests/integration/test_self_monitoring.py
+++ b/tests/integration/test_self_monitoring.py
@@ -24,7 +24,7 @@ async def test_deploy_and_relate_charms(ops_test: OpsTest, mimir_charm):
     # mimir_charm = await ops_test.build_charm(".")
     await asyncio.gather(
         ops_test.model.deploy(
-            await mimir_charm,
+            mimir_charm,
             resources={"mimir-image": oci_image("./metadata.yaml", "mimir-image")},
             application_name=MIMIR,
             trust=True,

--- a/tests/integration/test_self_monitoring.py
+++ b/tests/integration/test_self_monitoring.py
@@ -7,7 +7,7 @@ import logging
 
 import pytest
 import requests
-from helpers import get_unit_address, oci_image
+from helpers import get_address, oci_image
 from pytest_operator.plugin import OpsTest
 from workload import Mimir
 
@@ -43,14 +43,14 @@ async def test_deploy_and_relate_charms(ops_test: OpsTest, mimir_charm):
 
 
 async def test_metrics_are_available(ops_test):
-    address = await get_unit_address(ops_test, MIMIR, 0)
+    address = await get_address(ops_test, MIMIR, 0)
     mimir = Mimir(host=address)
     metrics = await mimir.api_request("/metrics")
     assert len(metrics) > 0
 
 
 async def test_query_metrics_from_prometheus(ops_test):
-    address = await get_unit_address(ops_test, PROMETHEUS, 0)
+    address = await get_address(ops_test, PROMETHEUS, 0)
     url = f"http://{address}:9090/api/v1/query"
     params = {"query": f"up{{juju_application='{MIMIR}'}}"}
     try:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = lint, static-{charm,lib}, scenario, unit
+envlist = lint, static-{charm,lib}, unit
 
 [vars]
 src_path = {toxinidir}/src

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = lint, static-{charm,lib}, unit
+envlist = lint, static-{charm,lib}, scenario, unit
 
 [vars]
 src_path = {toxinidir}/src

--- a/tox.ini
+++ b/tox.ini
@@ -105,6 +105,8 @@ deps =
     pytest
     juju
     pytest-operator
+    PyYAML
+    pytimeparse
     -r{toxinidir}/requirements.txt
 commands =
     pytest -vv --tb native --log-cli-level=INFO --color=yes -s {posargs} {toxinidir}/tests/integration


### PR DESCRIPTION
## Issue
No itest confirming alerts are generated from rules received.


## Solution
Use avalanche as the tester charm. Forward metrics+rules over remote-write.

Drive-by fixes:
- Change base from 22.04 to 20.04.
- Fetch cos-tool.
- Drop StoredState.

## Context
NTA.


## Testing Instructions
1. Relate mimir and avalanche.
2. `curl $mimir:9009/prometheus/api/v1/alerts` should be non-empty.


## Release Notes
Add alert rule propagation itest.
