### PR TITLE
use ruff instead of flake8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,6 @@ per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
 [tool.ruff.pydocstyle]
 convention = "google"
 
-[tool.ruff.mccabe]
-max-complexity = 10
-
 # Static analysis tools configuration
 [tool.mypy]
 pretty = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,27 +10,22 @@ show_missing = true
 line-length = 99
 target-version = ["py38"]
 
-[tool.isort]
-line_length = 99
-profile = "black"
-
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
-max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
+[tool.ruff]
+line-length = 99
+extend-exclude = ["__pycache__", "*.egg_info"]
+select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
+# Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
+ignore = ["E501", "D107", "RET504"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103"]
-docstring-convention = "google"
-# Check for properly formatted copyright header in each file
-copyright-check = "True"
-copyright-author = "Canonical Ltd."
-copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.mccabe]
+max-complexity = 10
 
 # Static analysis tools configuration
 [tool.mypy]

--- a/src/charm.py
+++ b/src/charm.py
@@ -314,7 +314,7 @@ class MimirK8SOperatorCharm(CharmBase):
             raise BlockedStatusError("Failed to remove alerts directory; see debug logs")
 
         try:
-            self._push_alert_rules(self.remote_write_provider.alerts())
+            self._push_alert_rules(self.remote_write_provider.alerts())  # type: ignore
         except (ProtocolError, PathError) as e:
             logger.error("Failed to push updated alert files: %s", e)
             raise BlockedStatusError("Failed to push updated alert files; see debug logs")

--- a/tests/integration/workload.py
+++ b/tests/integration/workload.py
@@ -85,6 +85,5 @@ class Mimir:
                 if response_type == "json":
                     result = await response.json()
                     return result if response.status == 200 else ""
-                else:
-                    result = await response.text()
-                    return result if response.status == 200 else ""
+                result = await response.text()
+                return result if response.status == 200 else ""

--- a/tests/scenario/test_deploy.py
+++ b/tests/scenario/test_deploy.py
@@ -4,12 +4,11 @@
 from unittest.mock import Mock, PropertyMock
 
 import pytest
+from charm import BlockedStatusError, MimirK8SOperatorCharm
 from charms.harness_extensions.v0.evt_sequences import Event, Scenario
 from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
 from ops.model import BlockedStatus, Container, WaitingStatus
 from ops.pebble import ProtocolError
-
-from charm import BlockedStatusError, MimirK8SOperatorCharm
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,11 +7,10 @@ import unittest
 from unittest.mock import Mock, PropertyMock, patch
 
 import ops.testing
+from charm import BlockedStatusError, MimirK8SOperatorCharm
 from ops.model import ActiveStatus, BlockedStatus, Container, WaitingStatus
 from ops.pebble import ProtocolError
 from ops.testing import Harness
-
-from charm import BlockedStatusError, MimirK8SOperatorCharm
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,31 +26,23 @@ passenv =
 description = Apply coding style standards to code
 deps =
     black
-    isort
+    ruff
 commands =
-    isort {[vars]all_path}
+    ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
+    ruff
     codespell
-    flake8 < 5
-    flake8-docstrings
-    flake8-copyright
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
 commands =
     # uncomment the following line if this charm owns a lib
     # codespell {[vars]lib_path}
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache \
       --skip icon.svg --skip prometheus_alert_rules --skip grafana_dashboards
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static-charm]


### PR DESCRIPTION
The **flake8** plugins we use are re-implemented in **ruff**, which is why they have been removed from the dependencies.

**isort** is enabled (and used when formatting) through the `I001` rule.

The "exclude list" has been updated to omit folders that **ruff** excludes by default.

Everything else is the same, the only difference being one new rule being ignored (which was't checked before anyway): 
* `RET504: Unnecessary variable assignment before return statement`, which we do everywhere as it increases readability.